### PR TITLE
Upsun Config updates

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -89,7 +89,9 @@ services:
         type: redis:8.0
 
     es:
-        type: elasticsearch:8.19
+        type: elasticsearch:7.10
+    os:
+        type: opensearch:3
 
 routes:
     # The routes of the project.

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -83,7 +83,7 @@ applications:
 
 services:
     ggdb:
-        type: mariadb:11.4
+        type: mariadb:11.8
 
     redis:
         type: redis:8.0

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -6,7 +6,7 @@ applications:
             root: "gg"
 
         # The runtime the application uses.
-        type: "php:8.4"
+        type: "php:8.5"
 
         runtime:
             extensions:
@@ -86,10 +86,10 @@ services:
         type: mariadb:11.4
 
     redis:
-        type: redis:7.2
+        type: redis:8.0
 
     es:
-        type: elasticsearch:7.10
+        type: elasticsearch:8.19
 
 routes:
     # The routes of the project.


### PR DESCRIPTION
This pull request updates several dependencies and service versions in the `.upsun/config.yaml` file to keep the project up-to-date and introduce new capabilities. The most notable changes are upgrading the PHP runtime, MariaDB, and Redis versions, and adding a new OpenSearch service.

Dependency and service upgrades:

* Upgraded the PHP runtime version for the application from `php:8.4` to `php:8.5` to ensure compatibility with the latest PHP features and security updates.
* Updated the `ggdb` service from `mariadb:11.4` to `mariadb:11.8` for improved database performance and security.
* Updated the `redis` service from `redis:7.2` to `redis:8.0` to take advantage of new Redis features and improvements.

New service addition:

* Added a new `os` service using `opensearch:3` to provide enhanced search capabilities alongside the existing `elasticsearch` service.This pull request updates the technology stack versions in the `.upsun/config.yaml` file to ensure compatibility with the latest features and security updates. The most important changes are grouped by application and service updates:

Application runtime update:
* Upgraded the PHP runtime version from `php:8.4` to `php:8.5` for the main application (`gg`).

Service version updates:
* Updated the Redis service from `redis:7.2` to `redis:8.0`.
* Updated the Elasticsearch service from `elasticsearch:7.10` to `elasticsearch:8.19`.