### PR TITLE
Improve newsletter form styling

### DIFF
--- a/gg/mu-plugins/gg-styles/form-style.css
+++ b/gg/mu-plugins/gg-styles/form-style.css
@@ -1,69 +1,174 @@
-/* --- MC4WP Styling to match WPForms --- */
+/* Newsletter form */
 
 .mc4wp-form {
-	margin-bottom: 30px;
+	max-width: 760px;
+	margin: 36px auto 0;
+	color: var(--wp--preset--color--contrast, #111);
 }
 
-/* Labels */
+.mc4wp-form-fields > div {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 24px;
+}
+
+.mc4wp-form-fields p {
+	min-width: 0;
+	margin: 0;
+}
+
+.mc4wp-form-fields > div > p:nth-of-type(3) {
+	grid-column: 1 / -1;
+}
+
 .mc4wp-form label {
 	display: block;
-	font-weight: 700;
-	margin-bottom: 8px;
-	font-size: 16px;
-	color: #333;
+	margin: 0 0 8px;
+	color: var(--wp--preset--color--contrast, #111);
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.4;
 }
 
-/* Inputs */
 .mc4wp-form input[type="email"],
 .mc4wp-form input[type="text"],
 .mc4wp-form select {
 	box-sizing: border-box;
 	width: 100%;
-	padding: 10px 15px;
+	min-height: 52px;
+	margin: 0;
+	padding: 12px 16px;
+	border: 1px solid var(--wp--preset--color--accent, #cfcabe);
+	border-radius: 8px;
+	background: var(--wp--preset--color--base, #f9f9f9);
+	color: var(--wp--preset--color--contrast, #111);
+	font: inherit;
 	font-size: 16px;
-	border: 1px solid #ccc;
-	border-radius: 3px;
-	background-color: #fff;
-	margin-bottom: 20px;
-	color: #333;
+	transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
 }
 
-/* Focus States */
+.mc4wp-form label > input[type="email"] {
+	margin-top: 8px;
+}
+
+.mc4wp-form input[type="email"]::placeholder,
+.mc4wp-form input[type="text"]::placeholder {
+	color: var(--wp--preset--color--contrast-2, #636363);
+	opacity: 0.8;
+}
+
+.mc4wp-form input[type="email"]:hover,
+.mc4wp-form input[type="text"]:hover,
+.mc4wp-form select:hover {
+	border-color: var(--wp--preset--color--contrast-3, #a4a4a4);
+	background: var(--wp--preset--color--base-2, #fff);
+}
+
 .mc4wp-form input[type="email"]:focus,
-.mc4wp-form input[type="text"]:focus {
-	border-color: #666;
+.mc4wp-form input[type="text"]:focus,
+.mc4wp-form select:focus {
+	border-color: var(--wp--preset--color--contrast, #111);
 	outline: none;
+	background: var(--wp--preset--color--base-2, #fff);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--wp--preset--color--accent-4, #b1c5a4) 55%, transparent);
 }
 
-/* Submit Button */
-.mc4wp-form input[type="submit"] {
-	display: inline-block;
-	vertical-align: middle;
-	background-color: #0d0d0d;
-	color: #ffffff;
-	border: none;
-	border-radius: 3px;
-	padding: 12px 25px;
-	font-size: 16px;
+/* Keep the two interests together as a compact choice group. */
+.mc4wp-form-fields > div > p:nth-of-type(4) {
+	display: grid;
+	grid-template-columns: repeat(2, max-content);
+	align-content: end;
+	gap: 10px 12px;
+}
+
+.mc4wp-form-fields > div > p:nth-of-type(4) > label:first-child {
+	grid-column: 1 / -1;
+	margin: 0;
+}
+
+.mc4wp-form-fields > div > p:nth-of-type(4) > label:not(:first-child) {
+	display: inline-flex;
+	align-items: center;
+	margin: 0;
+	padding: 9px 12px;
+	border: 1px solid var(--wp--preset--color--accent, #cfcabe);
+	border-radius: 8px;
+	background: var(--wp--preset--color--base, #f9f9f9);
+	font-size: 15px;
 	font-weight: 500;
 	cursor: pointer;
+}
+
+.mc4wp-form input[type="checkbox"] {
+	width: 18px !important;
+	height: 18px;
+	margin: 0 9px 0 0;
+	accent-color: var(--wp--preset--color--contrast, #111);
+	transform: none;
+}
+
+.mc4wp-form input[type="submit"] {
+	box-sizing: border-box;
 	width: 100%;
-	transition: background-color 0.3s ease;
+	min-height: 52px;
+	padding: 12px 24px;
+	border: 1px solid var(--wp--preset--color--contrast, #111);
+	border-radius: 8px;
+	background: var(--wp--preset--color--contrast, #111);
+	color: var(--wp--preset--color--base-2, #fff);
+	font: inherit;
+	font-size: 16px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: transform 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
 }
 
 .mc4wp-form input[type="submit"]:hover {
-	background-color: #333333;
+	background: color-mix(in srgb, var(--wp--preset--color--contrast, #111) 84%, white);
+	box-shadow: 0 6px 18px rgb(17 17 17 / 14%);
+	transform: translateY(-1px);
 }
 
-/* Checkbox Groups Fix */
-.mc4wp-form input[type="checkbox"] {
-	width: auto !important;
-	margin-right: 10px;
-	transform: scale(1.2);
+.mc4wp-form input[type="submit"]:focus-visible,
+.mc4wp-form input[type="checkbox"]:focus-visible {
+	outline: 2px solid var(--wp--preset--color--contrast, #111);
+	outline-offset: 3px;
 }
 
-.mc4wp-form label:has(input[type="checkbox"]) {
-	font-weight: 400;
-	display: flex;
-	align-items: center;
+.mc4wp-response:not(:empty) {
+	margin-top: 20px;
+	padding: 14px 16px;
+	border-radius: 8px;
+	background: var(--wp--preset--color--base, #f9f9f9);
+}
+
+@media (max-width: 700px) {
+	.mc4wp-form {
+		margin-top: 28px;
+	}
+
+	.mc4wp-form-fields > div {
+		grid-template-columns: minmax(0, 1fr);
+		gap: 20px;
+	}
+
+	.mc4wp-form-fields > div > p:nth-of-type(3) {
+		grid-column: auto;
+	}
+}
+
+@media (max-width: 430px) {
+	.mc4wp-form-fields > div > p:nth-of-type(4) {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.mc4wp-form-fields > div > p:nth-of-type(4) > label:first-child {
+		grid-column: auto;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.mc4wp-form input {
+		transition: none;
+	}
 }

--- a/gg/mu-plugins/gg-styles/plugin.php
+++ b/gg/mu-plugins/gg-styles/plugin.php
@@ -12,7 +12,7 @@ add_action( 'wp_enqueue_scripts', function() {
 			'gratia-mc4wp-styles', // Handle name
 			plugins_url( 'form-style.css', __FILE__ ), // URL to the CSS file
 			[],
-			'1.0.0'
+			'1.1.0'
 		);
 
 	}


### PR DESCRIPTION
## Summary
- reshape the Mailchimp form into a compact two-column desktop layout
- add responsive single-column styling for mobile screens
- improve choice controls, focus states, hover feedback, and response messaging
- bump the stylesheet version to refresh cached assets

## Verification
- php -l gg/mu-plugins/gg-styles/plugin.php
- composer validate --no-check-publish --no-interaction
- git diff --check
- visually checked at 1280px and 390px