### PR TITLE
Remove Elasticsearch and Jetpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,14 @@ jobs:
           test -f wordpress/wp-content/mu-plugins/upsun-loader.php
           test -f wordpress/wp-content/mu-plugins/site-config.php
           test -f wordpress/wp-content/mu-plugins/gg-styles.php
+          test -f wordpress/wp-content/mu-plugins/gg-styles/legacy-tiled-gallery.css
           test -f wordpress/wp-content/object-cache.php
           test -d wordpress/wp-content/themes/twentytwentyfour
           test ! -d wordpress/wp-content/themes/twentytwentythree
           test ! -d wordpress/wp-content/themes/twentytwentyfive
           test ! -f wordpress/wp-content/plugins/hello.php
+          test ! -d wordpress/wp-content/plugins/elasticpress
+          test ! -d wordpress/wp-content/plugins/jetpack
           test ! -d wordpress/wp-content/plugins/really-simple-ssl
           test ! -d wordpress/wp-content/plugins/wp-cloudflare-page-cache
           test ! -d wordpress/wp-content/plugins/wordpress-importer

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -22,7 +22,6 @@ applications:
     relationships:
       database: "ggdb:mysql"
       rediscache: "redis:redis"
-      essearch: "es:elasticsearch"
 
     # Preserve the data behind the legacy Platform.sh local mounts. Changing
     # these to storage would attach new, empty volumes.
@@ -86,9 +85,6 @@ services:
     type: mariadb:11.8
   redis:
     type: redis:8.0
-  # ElasticPress search features are active in production.
-  es:
-    type: elasticsearch:7.10
 
 routes:
   "https://www.gratia.gratis/":

--- a/gg/README.md
+++ b/gg/README.md
@@ -47,11 +47,9 @@ wp-admin on Upsun.
 
 ## Upsun runtime and caching
 
-The `gg` application uses PHP 8.4 with MariaDB, Redis, and Elasticsearch.
-ElasticPress and Jetpack remain installed because their production features
-are active. Uploads and cache files retain the legacy mount data through
-`source: instance`. `www.gratia.gratis` is canonical and the apex redirects to
-it.
+The `gg` application uses PHP 8.4 with MariaDB and Redis. Uploads and cache
+files retain the legacy mount data through `source: instance`.
+`www.gratia.gratis` is canonical and the apex redirects to it.
 
 Cloudflare provides CDN and security services and caches static assets. The
 Upsun router is the only full-page HTML cache. WordPress page-cache plugins
@@ -95,10 +93,11 @@ exception or return `false` to abort deployment and leave the migration
 pending. Successful migrations are recorded in the database and follow cloned
 data.
 
-The included migrations remove only Really Simple Security, the WordPress
-Cloudflare page-cache plugin, and WordPress Importer state. User-authored and
-previously imported content is preserved. Jetpack and ElasticPress cleanup is
-deliberately excluded after the production usage audit.
+The included migrations remove obsolete plugin activation and settings state,
+including Really Simple Security, the WordPress Cloudflare page-cache plugin,
+WordPress Importer, ElasticPress, and Jetpack. User-authored and previously
+imported content is preserved, including content created with Jetpack blocks.
+The site styles MU plugin retains the layout of saved tiled-gallery blocks.
 
 ## Cron, CI, and backups
 

--- a/gg/composer.json
+++ b/gg/composer.json
@@ -34,8 +34,6 @@
     "platformsh/config-reader": "^3.0",
     "wpackagist-plugin/akismet": "^5.0",
     "wpackagist-plugin/database-for-wpforms": "^1.0",
-    "wpackagist-plugin/elasticpress": "^5.1.3",
-    "wpackagist-plugin/jetpack": "^16.0",
     "wpackagist-plugin/mailchimp-for-wp": "^4.10",
     "wpackagist-plugin/polylang": "^3.6",
     "wpackagist-plugin/redis-cache": "^2.8",
@@ -65,8 +63,6 @@
       "enable-plugins": [
         "akismet",
         "database-for-wpforms",
-        "elasticpress",
-        "jetpack",
         "mailchimp-for-wp",
         "polylang",
         "redis-cache",

--- a/gg/composer.lock
+++ b/gg/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc4482807a3a79e6d610a6830ae36ca1",
+    "content-hash": "739e78721fe1e2ff6e72f230788e00b8",
     "packages": [
         {
             "name": "artetecha/upsun-wp",
@@ -442,42 +442,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/database-for-wpforms/"
-        },
-        {
-            "name": "wpackagist-plugin/elasticpress",
-            "version": "5.3.3",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/elasticpress/",
-                "reference": "tags/5.3.3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/elasticpress.5.3.3.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/elasticpress/"
-        },
-        {
-            "name": "wpackagist-plugin/jetpack",
-            "version": "16.0.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/16.0.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.16.0.1.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/jetpack/"
         },
         {
             "name": "wpackagist-plugin/mailchimp-for-wp",

--- a/gg/migrations/20260730_0001_remove_elasticpress_and_jetpack.php
+++ b/gg/migrations/20260730_0001_remove_elasticpress_and_jetpack.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Remove ElasticPress and Jetpack activation, settings, and scheduled jobs.
+ *
+ * Posts, attachments, and block markup are intentionally preserved.
+ */
+
+return static function () {
+	global $wpdb;
+
+	$plugin_files = array(
+		'elasticpress/elasticpress.php',
+		'jetpack/jetpack.php',
+	);
+
+	$delete_prefixes = static function ( string $table, string $column, array $prefixes ) use ( $wpdb ): void {
+		foreach ( $prefixes as $prefix ) {
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$table} WHERE {$column} LIKE %s",
+					$wpdb->esc_like( $prefix ) . '%'
+				)
+			);
+			if ( false === $result ) {
+				throw new RuntimeException( "Failed to delete {$prefix} records from {$table}: {$wpdb->last_error}" );
+			}
+		}
+	};
+
+	$cleanup_blog = static function () use ( $wpdb, $plugin_files, $delete_prefixes ): void {
+		$active_plugins = get_option( 'active_plugins', array() );
+		if ( is_array( $active_plugins ) ) {
+			$filtered = array_values( array_diff( $active_plugins, $plugin_files ) );
+			if ( $filtered !== $active_plugins && ! update_option( 'active_plugins', $filtered ) ) {
+				throw new RuntimeException( 'Failed to remove ElasticPress and Jetpack from active_plugins.' );
+			}
+		}
+
+		$delete_prefixes(
+			$wpdb->options,
+			'option_name',
+			array(
+				'ep_',
+				'elasticpress_',
+				'jetpack_',
+				'jp_',
+				'_transient_ep_',
+				'_transient_timeout_ep_',
+				'_transient_jetpack_',
+				'_transient_timeout_jetpack_',
+				'_transient_jp_',
+				'_transient_timeout_jp_',
+			)
+		);
+
+		foreach ( array( 'stats_options', 'stats_dashboard_widget' ) as $option ) {
+			delete_option( $option );
+		}
+
+		$cron = _get_cron_array();
+		if ( is_array( $cron ) ) {
+			$hooks = array();
+			foreach ( $cron as $events ) {
+				foreach ( array_keys( $events ) as $hook ) {
+					if (
+						str_starts_with( $hook, 'ep_' )
+						|| str_starts_with( $hook, 'jetpack_' )
+						|| str_starts_with( $hook, 'jp_' )
+						|| str_starts_with( $hook, 'grunion_' )
+						|| str_starts_with( $hook, 'wordads_' )
+					) {
+						$hooks[ $hook ] = true;
+					}
+				}
+			}
+			foreach ( array_keys( $hooks ) as $hook ) {
+				$result = wp_clear_scheduled_hook( $hook );
+				if ( false === $result || is_wp_error( $result ) ) {
+					throw new RuntimeException( "Failed to clear the {$hook} cron hook." );
+				}
+			}
+		}
+
+		$administrator = get_role( 'administrator' );
+		if ( $administrator ) {
+			$administrator->remove_cap( 'manage_elasticpress' );
+		}
+	};
+
+	$original_blog_id = get_current_blog_id();
+	$site_ids         = is_multisite()
+		? get_sites( array( 'fields' => 'ids', 'number' => 0 ) )
+		: array( $original_blog_id );
+
+	foreach ( $site_ids as $site_id ) {
+		$switched = is_multisite() && (int) $site_id !== get_current_blog_id();
+		if ( $switched ) {
+			switch_to_blog( (int) $site_id );
+		}
+		try {
+			$cleanup_blog();
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+	}
+
+	$delete_prefixes( $wpdb->usermeta, 'meta_key', array( 'jetpack_', 'jp_' ) );
+
+	if ( is_multisite() ) {
+		$delete_prefixes(
+			$wpdb->sitemeta,
+			'meta_key',
+			array(
+				'ep_',
+				'elasticpress_',
+				'jetpack_',
+				'jp_',
+				'_site_transient_ep_',
+				'_site_transient_timeout_ep_',
+				'_site_transient_jetpack_',
+				'_site_transient_timeout_jetpack_',
+				'_site_transient_jp_',
+				'_site_transient_timeout_jp_',
+			)
+		);
+
+		$network_plugins = get_site_option( 'active_sitewide_plugins', array() );
+		if ( is_array( $network_plugins ) ) {
+			$filtered = array_diff_key( $network_plugins, array_flip( $plugin_files ) );
+			if ( $filtered !== $network_plugins && ! update_site_option( 'active_sitewide_plugins', $filtered ) ) {
+				throw new RuntimeException( 'Failed to remove network-active ElasticPress and Jetpack plugins.' );
+			}
+		}
+	}
+
+	wp_cache_flush();
+};

--- a/gg/mu-plugins/gg-styles/legacy-tiled-gallery.css
+++ b/gg/mu-plugins/gg-styles/legacy-tiled-gallery.css
@@ -1,0 +1,69 @@
+/* Preserve the layout of saved Jetpack tiled-gallery blocks after removal. */
+
+.tiled-gallery__gallery {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+	padding: 0;
+}
+
+.tiled-gallery__row {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	width: 100%;
+	margin: 0;
+}
+
+.tiled-gallery__row + .tiled-gallery__row {
+	margin-top: 4px;
+}
+
+.tiled-gallery__col {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-width: 0;
+	margin: 0;
+}
+
+.tiled-gallery__col + .tiled-gallery__col {
+	margin-inline-start: 4px;
+}
+
+.tiled-gallery__item {
+	position: relative;
+	display: flex;
+	flex-grow: 1;
+	justify-content: center;
+	min-width: 0;
+	margin: 0;
+	padding: 0;
+	overflow: hidden;
+}
+
+.tiled-gallery__item + .tiled-gallery__item {
+	margin-top: 4px;
+}
+
+.tiled-gallery__item > a,
+.tiled-gallery__item > a > img,
+.tiled-gallery__item > img {
+	display: block;
+	width: 100%;
+	height: auto;
+	max-width: 100%;
+	margin: 0;
+	padding: 0;
+	object-fit: cover;
+	object-position: center;
+}
+
+.wp-block-jetpack-tiled-gallery.is-style-circle .tiled-gallery__item img {
+	aspect-ratio: 1;
+	border-radius: 50%;
+}
+
+.wp-block-jetpack-tiled-gallery.is-style-square .tiled-gallery__item img {
+	aspect-ratio: 1;
+}

--- a/gg/mu-plugins/gg-styles/plugin.php
+++ b/gg/mu-plugins/gg-styles/plugin.php
@@ -16,4 +16,14 @@ add_action( 'wp_enqueue_scripts', function() {
 		);
 
 	}
+
+	// Jetpack previously supplied the layout for saved tiled-gallery blocks.
+	if ( file_exists( plugin_dir_path( __FILE__ ) . 'legacy-tiled-gallery.css' ) ) {
+		wp_enqueue_style(
+			'gratia-legacy-tiled-gallery',
+			plugins_url( 'legacy-tiled-gallery.css', __FILE__ ),
+			array(),
+			'1.0.0'
+		);
+	}
 });

--- a/gg/wp-config.php
+++ b/gg/wp-config.php
@@ -132,10 +132,6 @@ if ( $config->isValidPlatform() ) {
 		define( 'WP_ENVIRONMENT_TYPE', $wp_environment_type );
 	}
 
-	if ( ! $config->onProduction() && ! defined( 'JETPACK_DEV_DEBUG' ) ) {
-		define( 'JETPACK_DEV_DEBUG', true );
-	}
-
 	// Composer owns the read-only application tree on Upsun.
 	if ( ! defined( 'DISALLOW_FILE_MODS' ) ) {
 		define( 'DISALLOW_FILE_MODS', true );


### PR DESCRIPTION
## Summary

- remove the Upsun Elasticsearch service and application relationship
- remove ElasticPress and Jetpack from Composer and default activation
- clean plugin activation, settings, credentials, cron events, and ElasticPress capability during deployment
- preserve authored content and saved Jetpack tiled-gallery layouts with a small site-owned stylesheet
- assert both plugins remain absent in CI

## Validation

- composer validate --strict
- PHP lint for all MU plugins and migrations
- composer build placement checks
- Upsun application configuration validation
- git diff --check