### PR TITLE
Fix newsletter checkbox option styling

### DIFF
--- a/gg/themes/gratia-gratis/assets/css/theme.css
+++ b/gg/themes/gratia-gratis/assets/css/theme.css
@@ -762,12 +762,17 @@ a:hover {
 	display: flex;
 	align-items: center;
 	gap: 0.55rem;
+	padding: 0;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
 	color: var(--wp--preset--color--paper);
 	font-size: inherit;
 	font-weight: 400;
 	letter-spacing: normal;
 	margin-bottom: 0;
 	text-transform: none;
+	cursor: pointer;
 }
 
 .gg-newsletter .mc4wp-form-fields > div > p:nth-child(4) > label:first-child {


### PR DESCRIPTION
## Summary
- remove inherited white card styling from newsletter checkbox labels
- preserve the dark newsletter layout and accessible clickable labels

## Verification
- inspected the production MC4WP markup and computed styles
- ran Composer validation
- verified the built theme matches its source
- ran git diff checks