### PR TITLE
Add shared header and footer navigation blocks

### DIFF
--- a/gg/README.md
+++ b/gg/README.md
@@ -116,11 +116,13 @@ pending. Successful migrations are recorded in the database and follow cloned
 data.
 
 The included migrations import the legacy book catalog into the Book content
-type and remove obsolete plugin activation and settings state, including
-Really Simple Security, the WordPress Cloudflare page-cache plugin, WordPress
-Importer, ElasticPress, and Jetpack. Other user-authored and previously
-imported content is preserved, including content created with Jetpack blocks.
-The site styles MU plugin retains the layout of saved tiled-gallery blocks.
+type, create the shared header and footer Navigation entities used by the
+block theme, and remove obsolete plugin activation and settings state,
+including Really Simple Security, the WordPress Cloudflare page-cache plugin,
+WordPress Importer, ElasticPress, and Jetpack. Other user-authored and
+previously imported content is preserved, including content created with
+Jetpack blocks. The site styles MU plugin retains the layout of saved
+tiled-gallery blocks.
 
 ## Cron, CI, and backups
 

--- a/gg/migrations/20260731_0002_create_shared_navigation.php
+++ b/gg/migrations/20260731_0002_create_shared_navigation.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Create the shared Navigation entities used by the block theme.
+ *
+ * Existing entities with the stable slugs are preserved so rerunning this
+ * callable never overwrites menu edits made in the Site Editor.
+ */
+
+return static function (): void {
+	if ( ! post_type_exists( 'wp_navigation' ) ) {
+		throw new RuntimeException( 'The WordPress Navigation post type is unavailable.' );
+	}
+
+	$menus = array(
+		'primary-navigation'       => array(
+			'title' => 'Primary navigation',
+			'links' => array(
+				array( 'Content', '/blog/' ),
+				array( 'Books', '/books/' ),
+				array( 'About us', '/about-us/' ),
+				array( 'Contact', '/contact-us/' ),
+			),
+		),
+		'footer-about-navigation'  => array(
+			'title' => 'Footer: About',
+			'links' => array(
+				array( 'Our team', '/about-us/' ),
+				array( 'Contact us', '/contact-us/' ),
+				array( 'Join us', '/contact-us/' ),
+			),
+		),
+		'footer-explore-navigation' => array(
+			'title' => 'Footer: Explore',
+			'links' => array(
+				array( 'Journal', '/blog/' ),
+				array( 'Books', '/books/' ),
+				array( 'Give', '/#donate' ),
+			),
+		),
+	);
+
+	foreach ( $menus as $slug => $menu ) {
+		$existing = get_page_by_path( $slug, OBJECT, 'wp_navigation' );
+		if ( $existing instanceof WP_Post ) {
+			continue;
+		}
+
+		$blocks = array();
+		foreach ( $menu['links'] as $link ) {
+			$blocks[] = sprintf(
+				'<!-- wp:navigation-link %s /-->',
+				wp_json_encode(
+					array(
+						'label'          => $link[0],
+						'url'            => $link[1],
+						'kind'           => 'custom',
+						'isTopLevelLink' => true,
+					),
+					JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+				)
+			);
+		}
+
+		$result = wp_insert_post(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_status'  => 'publish',
+				'post_title'   => $menu['title'],
+				'post_name'    => $slug,
+				'post_content' => implode( "\n", $blocks ),
+			),
+			true
+		);
+
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException(
+				sprintf( 'Could not create “%s”: %s', $menu['title'], $result->get_error_message() )
+			);
+		}
+	}
+};

--- a/gg/themes/gratia-gratis/README.md
+++ b/gg/themes/gratia-gratis/README.md
@@ -33,6 +33,12 @@ page-hero patterns are available in the inserter too.
    active on a temporary environment.
 5. The contact template styles the site's existing WPForms form.
 
+The project migration creates three shared Navigation entities: **Primary
+navigation**, **Footer: About**, and **Footer: Explore**. Edit them in the Site
+Editor's Navigation area; changes are reflected everywhere the corresponding
+header or footer menu is used. The theme patterns resolve these entities by
+stable slug, so their database IDs can differ safely between environments.
+
 The `/blog` slug has its own query template, so it works whether or not that
 page is selected as the Posts page under Reading settings.
 

--- a/gg/themes/gratia-gratis/assets/css/theme.css
+++ b/gg/themes/gratia-gratis/assets/css/theme.css
@@ -963,6 +963,26 @@ a:hover {
 	text-decoration-thickness: 1px;
 }
 
+.gg-footer .gg-footer-navigation {
+	margin-block-start: 1.5rem;
+	font-family: var(--wp--preset--font-family--serif);
+	font-size: var(--wp--preset--font-size--medium);
+	font-weight: 400;
+	letter-spacing: normal;
+	line-height: 1.55;
+	text-transform: none;
+	align-items: flex-start;
+}
+
+.gg-footer .gg-footer-navigation .wp-block-navigation__container {
+	gap: 0;
+	align-items: flex-start;
+}
+
+.gg-footer .gg-footer-navigation .wp-block-navigation-item__content {
+	padding: 0;
+}
+
 @media (max-width: 900px) {
 	.gg-home-hero {
 		min-height: auto;

--- a/gg/themes/gratia-gratis/functions.php
+++ b/gg/themes/gratia-gratis/functions.php
@@ -75,6 +75,26 @@ function gratia_gratis_register_pattern_categories() {
 add_action( 'init', 'gratia_gratis_register_pattern_categories' );
 
 /**
+ * Resolve a shared Navigation entity by its stable slug.
+ *
+ * Pattern files use this helper instead of hardcoding database-specific post
+ * IDs. The migration creates the entities, while the patterns retain embedded
+ * fallback links for fresh databases where migrations have not run yet.
+ *
+ * @param string $slug Navigation post slug.
+ * @return int Published Navigation post ID, or zero when it is unavailable.
+ */
+function gratia_gratis_get_navigation_id( $slug ) {
+	$navigation = get_page_by_path( sanitize_title( $slug ), OBJECT, 'wp_navigation' );
+
+	if ( ! $navigation instanceof WP_Post || 'publish' !== $navigation->post_status ) {
+		return 0;
+	}
+
+	return (int) $navigation->ID;
+}
+
+/**
  * Expose a few reusable block treatments in the editor.
  */
 function gratia_gratis_register_block_styles() {

--- a/gg/themes/gratia-gratis/patterns/footer.php
+++ b/gg/themes/gratia-gratis/patterns/footer.php
@@ -6,6 +6,13 @@
  * Block Types: core/template-part/footer
  * Inserter: no
  */
+
+$footer_about_navigation_id = function_exists( 'gratia_gratis_get_navigation_id' )
+	? gratia_gratis_get_navigation_id( 'footer-about-navigation' )
+	: 0;
+$footer_explore_navigation_id = function_exists( 'gratia_gratis_get_navigation_id' )
+	? gratia_gratis_get_navigation_id( 'footer-explore-navigation' )
+	: 0;
 ?>
 <!-- wp:group {"align":"full","className":"gg-footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull gg-footer has-white-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)">
@@ -19,12 +26,28 @@
 
 		<!-- wp:column {"width":"25%"} -->
 		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"className":"gg-eyebrow"} --><h3 class="wp-block-heading gg-eyebrow">About</h3><!-- /wp:heading -->
-		<!-- wp:list {"className":"is-style-none"} --><ul class="is-style-none"><li><a href="/about-us/">Our team</a></li><li><a href="/contact-us/">Contact us</a></li><li><a href="/contact-us/">Join us</a></li></ul><!-- /wp:list --></div>
+		<?php if ( $footer_about_navigation_id ) : ?>
+		<!-- wp:navigation {"ref":<?php echo absint( $footer_about_navigation_id ); ?>,"overlayMenu":"never","ariaLabel":"About","className":"gg-footer-navigation","layout":{"type":"flex","orientation":"vertical"}} /-->
+		<?php else : ?>
+		<!-- wp:navigation {"overlayMenu":"never","ariaLabel":"About","className":"gg-footer-navigation","layout":{"type":"flex","orientation":"vertical"}} -->
+			<!-- wp:navigation-link {"label":"Our team","url":"/about-us/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:navigation-link {"label":"Contact us","url":"/contact-us/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:navigation-link {"label":"Join us","url":"/contact-us/","kind":"custom","isTopLevelLink":true} /-->
+		<!-- /wp:navigation -->
+		<?php endif; ?></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column {"width":"25%"} -->
 		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"className":"gg-eyebrow"} --><h3 class="wp-block-heading gg-eyebrow">Explore</h3><!-- /wp:heading -->
-		<!-- wp:list {"className":"is-style-none"} --><ul class="is-style-none"><li><a href="/blog/">Journal</a></li><li><a href="/books/">Books</a></li><li><a href="/#donate">Give</a></li></ul><!-- /wp:list --></div>
+		<?php if ( $footer_explore_navigation_id ) : ?>
+		<!-- wp:navigation {"ref":<?php echo absint( $footer_explore_navigation_id ); ?>,"overlayMenu":"never","ariaLabel":"Explore","className":"gg-footer-navigation","layout":{"type":"flex","orientation":"vertical"}} /-->
+		<?php else : ?>
+		<!-- wp:navigation {"overlayMenu":"never","ariaLabel":"Explore","className":"gg-footer-navigation","layout":{"type":"flex","orientation":"vertical"}} -->
+			<!-- wp:navigation-link {"label":"Journal","url":"/blog/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:navigation-link {"label":"Books","url":"/books/","kind":"custom","isTopLevelLink":true} /-->
+			<!-- wp:navigation-link {"label":"Give","url":"/#donate","kind":"custom","isTopLevelLink":true} /-->
+		<!-- /wp:navigation -->
+		<?php endif; ?></div>
 		<!-- /wp:column -->
 	</div>
 	<!-- /wp:columns -->
@@ -34,4 +57,3 @@
 	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
-

--- a/gg/themes/gratia-gratis/patterns/header.php
+++ b/gg/themes/gratia-gratis/patterns/header.php
@@ -6,6 +6,10 @@
  * Block Types: core/template-part/header
  * Inserter: no
  */
+
+$primary_navigation_id = function_exists( 'gratia_gratis_get_navigation_id' )
+	? gratia_gratis_get_navigation_id( 'primary-navigation' )
+	: 0;
 ?>
 <!-- wp:group {"align":"full","className":"gg-header","style":{"spacing":{"padding":{"top":"1.4rem","bottom":"1.4rem","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"paper","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull gg-header has-paper-background-color has-background" style="padding-top:1.4rem;padding-right:var(--wp--preset--spacing--40);padding-bottom:1.4rem;padding-left:var(--wp--preset--spacing--40)">
@@ -18,12 +22,16 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"overlayMenu":"mobile","icon":"menu","layout":{"type":"flex","justifyContent":"center"}} -->
+		<?php if ( $primary_navigation_id ) : ?>
+		<!-- wp:navigation {"ref":<?php echo absint( $primary_navigation_id ); ?>,"overlayMenu":"mobile","icon":"menu","ariaLabel":"Primary navigation","layout":{"type":"flex","justifyContent":"center"}} /-->
+		<?php else : ?>
+		<!-- wp:navigation {"overlayMenu":"mobile","icon":"menu","ariaLabel":"Primary navigation","layout":{"type":"flex","justifyContent":"center"}} -->
 			<!-- wp:navigation-link {"label":"Content","url":"/blog/","kind":"custom","isTopLevelLink":true} /-->
 			<!-- wp:navigation-link {"label":"Books","url":"/books/","kind":"custom","isTopLevelLink":true} /-->
 			<!-- wp:navigation-link {"label":"About us","url":"/about-us/","kind":"custom","isTopLevelLink":true} /-->
 			<!-- wp:navigation-link {"label":"Contact","url":"/contact-us/","kind":"custom","isTopLevelLink":true} /-->
 		<!-- /wp:navigation -->
+		<?php endif; ?>
 
 		<!-- wp:group {"className":"gg-header-actions","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group gg-header-actions"><!-- wp:paragraph {"className":"gg-meta"} --><p class="gg-meta"><a href="/?s=">Search</a></p><!-- /wp:paragraph --><!-- wp:buttons -->


### PR DESCRIPTION
## Summary
- create database-backed Primary, Footer: About, and Footer: Explore Navigation entities through an idempotent deployment migration
- resolve Navigation post IDs dynamically in the theme patterns, with embedded fallback links for databases where migrations have not run
- convert both footer link columns to editable shared Navigation blocks
- preserve the current header behavior and footer typography/layout
- document where the shared menus are edited in the Site Editor

## Verification
- built the generated WordPress tree and compared the installed theme with its source
- ran Composer validation, theme.json parsing, and PHP linting across project and theme files
- parsed both migrated Navigation content and rendered header/footer patterns with and without database refs
- compared footer typography against the live site