### PR TITLE
Upgrade Upsun WordPress to 1.0

### DIFF
--- a/gg/composer.json
+++ b/gg/composer.json
@@ -26,7 +26,7 @@
   ],
   "require": {
     "php": ">=8.4",
-    "artetecha/upsun-wp": "^0.8",
+    "artetecha/upsun-wp": "^1.0",
     "composer/installers": "^2.3",
     "inpsyde/wp-translation-downloader": "^2.0",
     "johnpbloch/wordpress-core": "^7.0.0",

--- a/gg/composer.lock
+++ b/gg/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1ee589aefede5394dfc383b7ccb9cee",
+    "content-hash": "2d7c974de19a700f58c9268e6d457f63",
     "packages": [
         {
             "name": "artetecha/upsun-wp",
-            "version": "0.8.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/artetecha/upsun-wp.git",
-                "reference": "b2405c0c87880fb0cc53f17580abc02b9b1d621c"
+                "reference": "63c143a0c74cdcbe103cfb9ab03d0cf850c9be69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/artetecha/upsun-wp/zipball/b2405c0c87880fb0cc53f17580abc02b9b1d621c",
-                "reference": "b2405c0c87880fb0cc53f17580abc02b9b1d621c",
+                "url": "https://api.github.com/repos/artetecha/upsun-wp/zipball/63c143a0c74cdcbe103cfb9ab03d0cf850c9be69",
+                "reference": "63c143a0c74cdcbe103cfb9ab03d0cf850c9be69",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
                 "issues": "https://github.com/artetecha/upsun-wp/issues",
                 "source": "https://github.com/artetecha/upsun-wp"
             },
-            "time": "2026-07-27T06:38:51+00:00"
+            "time": "2026-07-31T14:53:37+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
## Summary

- Upgrade `artetecha/upsun-wp` from 0.8 to 1.0
- Refresh the Composer lockfile with the 1.0.0 package reference

## Testing

Not run (not requested)